### PR TITLE
Avoid bound methods

### DIFF
--- a/function.go
+++ b/function.go
@@ -180,7 +180,10 @@ func (f *Function[I, O]) deserialize(state dispatchproto.Any) (dispatchcoro.Inst
 // on a Dispatch endpoint.
 func (f *Function[I, O]) Register(endpoint *Dispatch) (string, dispatchproto.Function) {
 	f.endpoint = endpoint
-	return f.name, f.run
+
+	return f.name, func(ctx context.Context, req dispatchproto.Request) dispatchproto.Response {
+		return f.run(ctx, req)
+	}
 }
 
 func (c *Function[I, O]) entrypoint(input I) func() dispatchproto.Response {


### PR DESCRIPTION
The coroc compiler doesn't support them yet (see https://github.com/dispatchrun/coroutine/issues/132).

As a workaround, explicitly generate the same closure that the Go compiler would.