### PR TITLE
Work around an issue in the coroutine serialization layer

### DIFF
--- a/serde.go
+++ b/serde.go
@@ -17,7 +17,16 @@ type serializedDispatch struct {
 }
 
 func dispatchSerializer(s *types.Serializer, d *Dispatch) error {
-	types.SerializeT(s, serializedDispatch{d.opts, d.functions})
+	opts := make([]Option, 0, len(d.opts))
+	for _, opt := range d.opts {
+		if _, ok := opt.(AnyFunction); ok {
+			// No need to serialize these options, since we serialize the
+			// map of registered functions directly.
+			continue
+		}
+		opts = append(opts, opt)
+	}
+	types.SerializeT(s, serializedDispatch{opts, d.functions})
 	return nil
 }
 


### PR DESCRIPTION
There's a NPE when deserializing function options from https://github.com/dispatchrun/dispatch-go/pull/7. For some reason the coroutine serialization layer deserializes them as null.

Let's work around the issue for now in order to make progress. We don't need to serialize the function options because we serialize the function map directly.