### PR TITLE
Simplify unit testing using new `dispatchtest.Call` helper

### DIFF
--- a/dispatchtest/integration/main.go
+++ b/dispatchtest/integration/main.go
@@ -40,12 +40,9 @@ func run() error {
 		return strings.Repeat(stringified, doubled), nil
 	})
 
-	call, err := doubleAndRepeat.BuildCall(4)
-	if err != nil {
-		return fmt.Errorf("new call failed: %v", err)
-	}
+	runner := dispatchtest.NewRunner(stringify, double, doubleAndRepeat)
 
-	output, err := dispatchtest.Run[string](call, stringify, double, doubleAndRepeat)
+	output, err := dispatchtest.Call(runner, doubleAndRepeat, 4)
 	if err != nil {
 		return err
 	}

--- a/function_test.go
+++ b/function_test.go
@@ -36,23 +36,16 @@ func TestCoroutineReturn(t *testing.T) {
 		return strconv.Itoa(in), nil
 	})
 
-	call, err := stringify.BuildCall(11)
+	runner := dispatchtest.NewRunner(stringify)
+
+	output, err := dispatchtest.Call(runner, stringify, 11)
 	if err != nil {
 		t.Fatal(err)
-	}
-	output, err := dispatchtest.Run[string](call, stringify)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if output != "11" {
+	} else if output != "11" {
 		t.Errorf("unexpected output: %s", output)
 	}
 
-	call2, err := stringify.BuildCall(-23)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = dispatchtest.Run[string](call2, stringify)
+	_, err = dispatchtest.Call(runner, stringify, -23)
 	if err == nil || !strings.Contains(err.Error(), "InvalidArgument: -23") {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -72,23 +65,16 @@ func TestCoroutineExit(t *testing.T) {
 		panic("unreachable")
 	})
 
-	call, err := stringify.BuildCall(11)
+	runner := dispatchtest.NewRunner(stringify)
+
+	output, err := dispatchtest.Call(runner, stringify, 11)
 	if err != nil {
 		t.Fatal(err)
-	}
-	output, err := dispatchtest.Run[string](call, stringify)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if output != "11" {
+	} else if output != "11" {
 		t.Errorf("unexpected output: %s", output)
 	}
 
-	call2, err := stringify.BuildCall(-23)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = dispatchtest.Run[string](call2, stringify)
+	_, err = dispatchtest.Call(runner, stringify, -23)
 	if err == nil || !strings.Contains(err.Error(), "InvalidArgument: -23") {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
While writing a testing guide (https://github.com/dispatchrun/dispatch-go/wiki/Testing-Functions-&-Workflows), I found it was awkward having to manually build a call to the function I was testing, and then having to specify the output type parameter because of type erasure on the call.

I've reworked the test helper so that it's no longer necessary to build a call or to specify the output type.